### PR TITLE
fix table pagination to page 1 on data change

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -193,9 +193,9 @@ Template.tabular.onRendered(function () {
     // run
     if (tabularTable.name === lastTableName) {
       if (table) {
-        // passing `false` as the second arg tells it to
-        // reset the paging
-        table.ajax.reload(null, true);
+        // passing `true` as the second arg tells it to
+        // reset the paging, check line 243
+        table.ajax.reload(null, false);
       }
       return;
     }


### PR DESCRIPTION
@maxko87 this look like such an simple/obvious change, almost too easy for it to have been not caught earlier. I am a little skeptic, please review and let me know your thoughts on this.

This fix should prevent the UI table pages to be auto paginated to the first page when the data is updated.